### PR TITLE
ci: upgrade stale GitHub Actions versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,6 +69,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v7
       with:
-        go-version: 1.19
+        go-version: 1.26.0
 
     - name: Build
       run: go build ./cmd/microguy/main.go


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from `v3` to `v7` in both `go.yml` and `codeql.yml` (current stable major, verified against the actions/checkout repo tags).
- Bump `actions/setup-go` from `v3` to `v7` in `go.yml` (current stable major).
- Bump `go-version` in `go.yml` from `1.19` to `1.26.0` to match what `go.mod` actually declares now (`go 1.26.0`).
- Bump `github/codeql-action/{init,autobuild,analyze}` from `v2` to `v4` in `codeql.yml` (current stable major, verified against the codeql-action repo tags — `v2` is long deprecated).
- `metrics.yml` (`lowlighter/metrics@latest`) is intentionally left untouched — out of scope per the task this PR came from.

This is a pure version-bump PR — no workflow behavior changes. A follow-up PR (`ci/add-test-gate`) adds `go vet`/`go test`/`gofmt` steps on top of this branch.

## Test plan
- [x] Confirmed current major versions via GitHub API before bumping (not guessed): `actions/checkout` -> `v7`, `actions/setup-go` -> `v7`, `github/codeql-action` -> `v4`.
- [x] Confirmed `go.mod` declares `go 1.26.0` and matched `go-version` to it exactly.
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .` all still pass locally on this branch (workflow-only diff, no Go source touched).
- [ ] CI run on this PR (checkout/setup-go/CodeQL init/autobuild/analyze all succeed with new majors) — verify after opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXmPNJBsdksoQ3obkj6RJ5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated security analysis and continuous integration workflows to use newer action versions.
  * Updated the Go toolchain used by continuous integration to version 1.26.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->