### PR TITLE
k8s: add health probes, fix Service/label mismatches

### DIFF
--- a/deploy/k8/deployment.yml
+++ b/deploy/k8/deployment.yml
@@ -16,4 +16,22 @@ spec:
       - name: microman
         image: microman/deployment
         imagePullPolicy: Never
-      restartPolicy: Never
+        ports:
+        - name: http
+          containerPort: 6969
+        env:
+        - name: PORT
+          value: "6969"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      restartPolicy: Always

--- a/deploy/k8/service.yml
+++ b/deploy/k8/service.yml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: service
 spec:
-  type: NodePort  
+  type: NodePort
   ports:
   - name: http
     port: 80
-    targetPort: 3000
+    targetPort: 6969
   selector:
-    name: deployment
+    name: microman

--- a/docs/developer/kubernetes.md
+++ b/docs/developer/kubernetes.md
@@ -18,13 +18,24 @@ kubectl apply -f deploy/k8
 
 ### Updating your API
 
-To update your API, you will need to manually build a new docker image and bump the version in the `deploy/k8/deployment.yaml` file.
+To update your API, you will need to manually build a new docker image and bump the version in the `deploy/k8/deployment.yml` file.
 
 Once you have done that, you can run the following command to update your API:
 
 ```bash
 kubectl apply -f deploy/k8
 ```
+
+### Health checks
+
+The Deployment's container defines `livenessProbe` and `readinessProbe` checks against `GET /health` on port `6969` (the app's default `PORT`, see `app/settings.go`). Kubernetes uses these to know when a pod is up and ready to receive traffic, and to restart it if it stops responding. You can hit the same endpoint yourself once a pod is running:
+
+```bash
+kubectl port-forward deploy/deployment 6969:6969
+curl http://localhost:6969/health
+```
+
+If you change the port the app listens on (via the `PORT` env var), update the container's `env`, `ports.containerPort`, the two probes' `port`, and `service.yml`'s `targetPort` together — they all need to agree.
 
 ### Deleting your API
 
@@ -39,7 +50,7 @@ kubectl delete -f deploy/k8
 If you are having issues with your API, you can run the following command to get the logs:
 
 ```bash
-kubectl logs -f -l app=api
+kubectl logs -f -l name=microman
 ```
 
 ### Scaling your API
@@ -47,7 +58,7 @@ kubectl logs -f -l app=api
 To scale your API, you can run the following command:
 
 ```bash
-kubectl scale deployment api --replicas=3
+kubectl scale deployment deployment --replicas=3
 ```
 
 This will scale your API to 3 replicas.


### PR DESCRIPTION
## Summary

`deploy/k8/deployment.yml` had no `livenessProbe`/`readinessProbe` at all. Now that a real `GET /health` endpoint exists (`handlers/health.go`, registered in `server/routing.go`, returns `200 ok`), this wires it up for both probes on the container's actual listening port.

While fixing the port so the probes are correct, I found and fixed a couple of things in these files that were outright broken (not just old-but-fine):

- **`deployment.yml`**: `restartPolicy: Never` is invalid for a Deployment's pod template — Kubernetes only accepts `Always` there, so `kubectl apply` would have failed validation. Fixed to `Always`.
- **`deployment.yml`**: the container declared no `containerPort` or `env` at all. Added `containerPort: 6969` (the app's default `PORT`, per `app/settings.go`) and an explicit `PORT=6969` env var so the manifest is self-documenting and matches the new probes.
- **`service.yml`**: `selector: {name: deployment}` didn't match the pod label (`name: microman`, set in the Deployment's pod template), so the Service had zero endpoints — traffic could never reach a pod. Fixed to `name: microman`.
- **`service.yml`**: `targetPort: 3000` didn't match anything the app listens on. Fixed to `6969` to match the container port.
- **`docs/developer/kubernetes.md`**: fixed a reference to a nonexistent `deployment.yaml` (the real file is `deployment.yml`), corrected the `logs`/`scale` examples to use the manifests' actual label/resource names (`-l name=microman` and `deployment`, not `app=api` / `api`, neither of which exist in these manifests), and added a short section documenting the new probes and which fields must stay in sync if the port ever changes.

Left the `image: microman/deployment` / `imagePullPolicy: Never` pair alone — that's a plausible local-cluster convention (build locally, load into minikube, skip a registry pull), not an obviously-unfilled placeholder, so I didn't invent a registry path for it.

Out of scope per the parallel workstreams: no changes to Go source, `Dockerfile`, `deploy/build.sh`, `Makefile`, `.github/workflows/`, or `.travis.yml`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('deploy/k8/deployment.yml'))"` — parses cleanly
- [x] `python3 -c "import yaml; yaml.safe_load(open('deploy/k8/service.yml'))"` — parses cleanly
- [ ] `kubectl apply -f deploy/k8` against a real cluster (not run here — no cluster available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXmPNJBsdksoQ3obkj6RJ5