### PR TITLE
ci: make CI actually test the code, not just build it

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,16 @@ jobs:
       with:
         go-version: 1.26.0
 
+    - name: Check formatting
+      run: test -z "$(gofmt -l .)"
+
+    - name: Vet
+      run: go vet ./...
+
     - name: Build
       run: go build ./cmd/microguy/main.go
+
+    - name: Test
+      run: go test ./...
 
 


### PR DESCRIPTION
## Summary
`go.yml`'s only step was `go build ./cmd/microguy/main.go` — no `go vet`, no `go test`, no formatting check, despite the repo now having real test coverage (`app`, `auth`, `data`). This adds:
- `gofmt -l .` check, failing the job if it reports any file (`test -z "$(gofmt -l .)"`)
- `go vet ./...`
- `go test ./...`
- Keeps the existing `go build ./cmd/microguy/main.go` step as-is (matches `CLAUDE.md`'s "source of truth for what actually builds" note, so left it rather than switching to `go build ./...`)

No new tools beyond the stock Go toolchain (no golangci-lint etc.), so nothing here needs follow-up config to pass.

**Branch note:** this PR is based on `ci/upgrade-actions` (#69), not `main` directly, since it builds on that branch's `actions/checkout`/`actions/setup-go`/`go-version` bumps. Merge #69 first (or merge this into it and then that branch into `main`) — please don't merge this into `main` before #69 is in, or GitHub may show the version-bump diff as part of this PR too.

## Test plan
- [x] Ran the equivalent commands locally before adding them as CI gates, all clean:
  - `gofmt -l .` → no output
  - `go vet ./...` → clean
  - `go build ./cmd/microguy/main.go` → succeeds
  - `go test ./...` → all packages with tests (`app`, `auth`, `data`) pass
- [ ] Confirm the new CI job steps go green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXmPNJBsdksoQ3obkj6RJ5