### PR TITLE
Fix stale cmd/microbro paths in Dockerfile/build.sh, add Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # build stage
-FROM golang:alpine AS build-env
+FROM golang:1.26.8-alpine3.24 AS build-env
 RUN apk --no-cache add build-base git bzr mercurial gcc
 ADD . /src
-RUN cd /src/cmd/microbro && go build -o microman
+RUN cd /src/cmd/microguy && go build -o microman
 
 # final stage
-FROM alpine
+FROM alpine:3.24.1
 WORKDIR /app
-COPY --from=build-env /src/cmd/microbro/mircroman /app/
+COPY --from=build-env /src/cmd/microguy/microman /app/
 ENTRYPOINT ./microman

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: build vet fmt unit-tests functional-tests
+
+build:
+	go build ./...
+
+vet:
+	go vet ./...
+
+fmt:
+	gofmt -l .
+
+unit-tests:
+	go test ./...
+
+# There is no meaningful distinction yet between "unit" and "functional" tests
+# in this codebase — everything lives under `go test ./...`. This target is
+# wired to Jenkinsfile's `make functional-tests` step so CI doesn't break; it
+# intentionally just re-runs the same suite rather than faking a separate
+# functional-test suite that doesn't exist.
+functional-tests:
+	go test ./...

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -1,8 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
 echo "Checking dependencies and formatting..."
-cd ../ && go mod tidy && go mod vendor &&  gofmt ./ && golangci-lint run && cd deploy ;
+cd ../ && go mod tidy
+
+unformatted="$(gofmt -l .)"
+if [ -n "$unformatted" ]; then
+  echo "The following files are not gofmt'ed:"
+  echo "$unformatted"
+  exit 1
+fi
+
+if command -v golangci-lint >/dev/null 2>&1; then
+  golangci-lint run
+else
+  echo "golangci-lint not installed, skipping lint step"
+fi
+
+cd deploy
 
 echo "Building Binary Executable..."
-go build -o bin/ ./../cmd/microbro/;
+go build -o bin/ ./../cmd/microguy/;
 
 echo "Default Config Copying to build directory..."
 cp env bin/.env


### PR DESCRIPTION
## Summary

The build/deploy tooling had drifted from the actual repo layout (documented in `CLAUDE.md`'s gotchas section):

- `Dockerfile` and `deploy/build.sh` both built from `cmd/microbro/`, which doesn't exist — the real (only) command package is `cmd/microguy/`. `Dockerfile` also had a typo (`COPY --from=build-env /src/cmd/microbro/mircroman`, note "mircroman") that wouldn't even have matched the binary it built (`-o microman`), had the path been correct.
- `deploy/build.sh` assumed a `vendor/` directory that no longer exists (removed in a prior modernization pass to plain module-mode builds), and called `gofmt ./` with invalid/no-op syntax.
- `Jenkinsfile` invokes `make unit-tests` / `make functional-tests`, but there was no `Makefile` in the repo at all.

## Changes

- **`Dockerfile`**: build from `cmd/microguy/`, fix the `COPY` source path/typo, and pin the previously-floating `golang:alpine` / `alpine` base images to `golang:1.26.8-alpine3.24` and `alpine:3.24.1` (verified these tags exist on Docker Hub).
- **`deploy/build.sh`**: build from `cmd/microguy/`, drop `go mod vendor`, replace `gofmt ./` with `gofmt -l .` plus a real pass/fail check, and guard the `golangci-lint` step with a `command -v` check so a missing local install doesn't hard-fail the script (no `golangci-lint` config exists anywhere in the repo or in CI today, so this keeps the script's intent without making it brittle).
- **`Makefile`** (new): minimal, root-level. Targets: `build`, `vet`, `fmt`, `unit-tests`, `functional-tests`. `unit-tests` and `functional-tests` both run `go test ./...` — there's no meaningful unit/functional split in this codebase currently, so `functional-tests` is commented as intentionally the same suite rather than a fake separate one.

## Out of scope

Per the task, `.travis.yml`, `.github/workflows/`, and `deploy/k8/` are untouched — other workstreams own those in parallel.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make build`, `make vet`, `make fmt`, `make unit-tests`, `make functional-tests` all run successfully
- [x] `cd cmd/microguy && go build .` succeeds (confirms the corrected Dockerfile/build.sh path is real)
- [x] Verified `golang:1.26.8-alpine3.24` and `alpine:3.24.1` exist on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXmPNJBsdksoQ3obkj6RJ5