### PR TITLE
ci: make CI actually test the code, not just build it

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,16 @@ jobs:
       with:
         go-version: 1.26.0
 
+    - name: Check formatting
+      run: test -z "$(gofmt -l .)"
+
+    - name: Vet
+      run: go vet ./...
+
     - name: Build
       run: go build ./cmd/microguy/main.go
+
+    - name: Test
+      run: go test ./...
 
 


### PR DESCRIPTION
## Summary

(Re-opened as a fresh PR — the original #71 was auto-closed by GitHub when its base branch `ci/upgrade-actions` was deleted after merging, and GitHub doesn't allow reopening/retargeting a PR once that happens. Same branch, same commits, now based directly on `main` which already has the Actions version bumps from #69.)

`go.yml`'s only step was `go build ./cmd/microguy/main.go` — no `go vet`, no `go test`, no formatting check, despite the repo having real test coverage. Adds:
- `gofmt -l .` check (fails the job if anything is unformatted)
- `go vet ./...`
- `go test ./...`
- Keeps the existing build step

No new tooling beyond the stock Go toolchain. Verified locally (`go vet`, `go test`, `gofmt -l .`) all clean before adding as gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXmPNJBsdksoQ3obkj6RJ5