### PR TITLE
Add httptest coverage for handlers/ and auth/ JWT flow

### DIFF
--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// testSecretPlain is an arbitrary plaintext secret used only by tests.
+// FindSecret hex-decodes the SECRET env var, so tests must set SECRET to
+// the hex-encoded form of whatever plaintext secret they want to sign with.
+const testSecretPlain = "unit-test-signing-secret-for-microman"
+
+// setTestSecret configures the SECRET env var (hex-encoded, as FindSecret
+// requires) for the duration of t, so generateJWT/VerifyToken work without a
+// real deployment secret.
+func setTestSecret(t *testing.T) {
+	t.Helper()
+	t.Setenv("SECRET", hex.EncodeToString([]byte(testSecretPlain)))
+}
+
+func TestJWTMiddleware_MissingHeader(t *testing.T) {
+	setTestSecret(t)
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	handler := JWTMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if called {
+		t.Error("next handler should not have been called for a request with no Authorization header")
+	}
+}
+
+func TestJWTMiddleware_MalformedToken(t *testing.T) {
+	setTestSecret(t)
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	handler := JWTMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer this-is-not-a-jwt")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if called {
+		t.Error("next handler should not have been called for a malformed bearer token")
+	}
+}
+
+func TestJWTMiddleware_ValidToken(t *testing.T) {
+	setTestSecret(t)
+	token, err := generateJWT(42)
+	if err != nil {
+		t.Fatalf("generateJWT() error = %v", err)
+	}
+
+	var gotClaims *Claims
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims, ok := ClaimsFromContext(r.Context())
+		if !ok {
+			t.Error("claims not found on request context inside protected handler")
+		}
+		gotClaims = claims
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := JWTMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if gotClaims == nil || gotClaims.ID != 42 {
+		t.Errorf("claims = %+v, want ID = 42", gotClaims)
+	}
+}

--- a/auth/route_test.go
+++ b/auth/route_test.go
@@ -1,0 +1,138 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+// newTestRouter builds a bare mux.Router with only the auth package's routes
+// mounted, so these tests exercise AuthRoute end-to-end via ServeHTTP
+// without depending on server.InitRouter/InitRoutes.
+func newTestRouter() *mux.Router {
+	router := mux.NewRouter()
+	AuthRoute(router)
+	return router
+}
+
+// TestAuthRoute_Login_NonexistentUser exercises POST /auth/login with
+// valid-shaped credentials for a user that doesn't exist in any database.
+// There is no real MySQL connection available in this test environment (and
+// notably, auth.database is a package-level *sql.DB that is only ever
+// assigned by initDB, which nothing in this codebase calls, so it is nil at
+// runtime here) - FindUserByUsername ends up dereferencing that nil *sql.DB
+// and panics. This test tolerates that known failure mode: it recovers any
+// panic so the test process itself doesn't crash, and either way asserts
+// login never reports success (200) for a user that was never created.
+func TestAuthRoute_Login_NonexistentUser(t *testing.T) {
+	setTestSecret(t)
+	router := newTestRouter()
+
+	form := url.Values{}
+	form.Set("username", "nonexistentuser")
+	form.Set("password", "Passw0rd1")
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+				t.Logf("login handler panicked for a nonexistent user (known issue: auth.database is never initialized, so FindUserByUsername dereferences a nil *sql.DB): %v", r)
+			}
+		}()
+		router.ServeHTTP(rec, req)
+	}()
+
+	if !panicked && rec.Code == http.StatusOK {
+		t.Errorf("login with a nonexistent user unexpectedly succeeded: status=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAuthRoute_Me_NoAuthHeader(t *testing.T) {
+	setTestSecret(t)
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d, body=%q", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestAuthRoute_Me_MalformedToken(t *testing.T) {
+	setTestSecret(t)
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	req.Header.Set("Authorization", "Bearer garbage.token.value")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d, body=%q", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestAuthRoute_Me_ValidToken(t *testing.T) {
+	setTestSecret(t)
+	router := newTestRouter()
+
+	token, err := generateJWT(7)
+	if err != nil {
+		t.Fatalf("generateJWT() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%q", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var claims Claims
+	if err := json.NewDecoder(rec.Body).Decode(&claims); err != nil {
+		t.Fatalf("decoding /auth/me response body: %v", err)
+	}
+	if claims.ID != 7 {
+		t.Errorf("claims.ID = %d, want 7", claims.ID)
+	}
+}
+
+func TestAuthRoute_UserNew_NotImplemented(t *testing.T) {
+	setTestSecret(t)
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/user/new", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("status = %d, want %d, body=%q", rec.Code, http.StatusNotImplemented, rec.Body.String())
+	}
+}
+
+func TestAuthRoute_UserRemove_NotImplemented(t *testing.T) {
+	setTestSecret(t)
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/user/remove", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("status = %d, want %d, body=%q", rec.Code, http.StatusNotImplemented, rec.Body.String())
+	}
+}

--- a/handlers/docs_test.go
+++ b/handlers/docs_test.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDocs(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/docs", nil)
+	rec := httptest.NewRecorder()
+
+	Docs(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Docs() status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got, want := rec.Body.String(), "Docs"; got != want {
+		t.Errorf("Docs() body = %q, want %q", got, want)
+	}
+}

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealth(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	Health(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Health() status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got, want := rec.Body.String(), "ok"; got != want {
+		t.Errorf("Health() body = %q, want %q", got, want)
+	}
+}

--- a/handlers/home_test.go
+++ b/handlers/home_test.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHome(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/home", nil)
+	rec := httptest.NewRecorder()
+
+	Home(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Home() status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got, want := rec.Body.String(), HomeSecrets(); got != want {
+		t.Errorf("Home() body = %q, want %q", got, want)
+	}
+}

--- a/handlers/info_test.go
+++ b/handlers/info_test.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestInfoDealer(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/info", nil)
+	rec := httptest.NewRecorder()
+
+	InfoDealer(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("InfoDealer() status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got, want := rec.Body.String(), Informant(); got != want {
+		t.Errorf("InfoDealer() body = %q, want %q", got, want)
+	}
+}

--- a/handlers/redirect_test.go
+++ b/handlers/redirect_test.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRedirect(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	Redirect(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("Redirect() status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if got, want := rec.Header().Get("Location"), "/docs"; got != want {
+		t.Errorf("Redirect() Location header = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `httptest`-based tests for the simple, stable `handlers/` routes that had zero coverage: `Home`, `Redirect`, `Docs`, `InfoDealer`, `Health`. CRUD stubs (`add`/`get`/`edit`/`delete.go`) are intentionally left untouched — a parallel workstream may be actively rewriting them.
- Adds end-to-end coverage for `auth/middleware.go`'s `JWTMiddleware` and `auth/route.go`'s `AuthRoute`, built on a real `*mux.Router` via `AuthRoute(mux.NewRouter())` and exercised with `httptest.NewRecorder()` + `router.ServeHTTP(...)`: missing/malformed/valid bearer tokens against `GET /auth/me`, the `501` stubs on `POST /auth/user/new` and `POST /auth/user/remove`, and `POST /auth/login` with valid-shaped but nonexistent credentials.
- `auth/middleware_test.go` and `auth/route_test.go` are `package auth` (matching `auth/rules_test.go`'s existing convention) so they can call the unexported `generateJWT` to mint a real, valid token for the `/auth/me` success-path assertion, and decode the response body into the real `Claims` type to check the echoed `id` claim.
- Along the way, discovered and documented (via test comment + `t.Logf`, not a code fix — out of scope per instructions) that `POST /auth/login` for a nonexistent user currently panics rather than returning a clean 401: `auth.database` (the package-level `*sql.DB`) is only ever assigned inside `initDB()`, which nothing in the codebase calls, so `FindUserByUsername`'s `database.QueryRow(...)` dereferences a nil `*sql.DB`. The login test recovers that panic so it doesn't crash the test binary, and passes as long as the request never reports a `200`, so it stays valid whether or not `initDB` gets wired up in the future.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXmPNJBsdksoQ3obkj6RJ5