### PR TITLE
Add real MySQL-backed CRUD for an example items resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Table of contents
 - [x] Redirect
 - [x] JWT Ready
 - [ ] Auto Generated Api Docs
-- [ ] Example Database Use
+- [x] Example Database Use
 - [ ] Test Automation
 - [x] Users
 - [ ] Authentication

--- a/data/items.go
+++ b/data/items.go
@@ -1,0 +1,84 @@
+package data
+
+// CRUD logic for the `items` example resource (schema in schema.sql). This
+// exists purely to demonstrate real database-backed request handling in
+// handlers/add.go, get.go, edit.go and delete.go — it is intentionally a
+// minimal demo domain model, not a real product resource.
+
+import (
+	"database/sql"
+	"errors"
+)
+
+// Item is the example resource stored in the `items` table.
+type Item struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// ErrItemNotFound is returned by GetItem, UpdateItem and DeleteItem when no
+// row matches the requested id.
+var ErrItemNotFound = errors.New("item not found")
+
+// CreateItem inserts a new item and returns it with its generated ID
+// populated. Uses a parameterized query, never string concatenation.
+func CreateItem(db *sql.DB, name, value string) (Item, error) {
+	res, err := db.Exec("INSERT INTO items (name, value) VALUES (?, ?)", name, value)
+	if err != nil {
+		return Item{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Item{}, err
+	}
+	return Item{ID: int(id), Name: name, Value: value}, nil
+}
+
+// GetItem fetches a single item by id. Returns ErrItemNotFound if no row
+// matches.
+func GetItem(db *sql.DB, id int) (Item, error) {
+	var item Item
+	row := db.QueryRow("SELECT id, name, value FROM items WHERE id = ?", id)
+	if err := row.Scan(&item.ID, &item.Name, &item.Value); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Item{}, ErrItemNotFound
+		}
+		return Item{}, err
+	}
+	return item, nil
+}
+
+// UpdateItem updates the name and value of the item with the given id.
+// Returns ErrItemNotFound if no row matches.
+func UpdateItem(db *sql.DB, id int, name, value string) (Item, error) {
+	res, err := db.Exec("UPDATE items SET name = ?, value = ? WHERE id = ?", name, value, id)
+	if err != nil {
+		return Item{}, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return Item{}, err
+	}
+	if rows == 0 {
+		return Item{}, ErrItemNotFound
+	}
+	return Item{ID: id, Name: name, Value: value}, nil
+}
+
+// DeleteItem deletes the item with the given id. Returns ErrItemNotFound if
+// no row matches.
+func DeleteItem(db *sql.DB, id int) error {
+	res, err := db.Exec("DELETE FROM items WHERE id = ?", id)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrItemNotFound
+	}
+	return nil
+}

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -1,0 +1,14 @@
+-- Schema for the `items` example resource used by the /add, /get, /edit and
+-- /delete handlers to demonstrate real (as opposed to stubbed) MySQL-backed
+-- CRUD via the data package. Written for the MySQL engine this project's
+-- datastation-backed Connect() targets.
+--
+-- Apply it against the database named by DATABASE_NAME (see data/connection.go)
+-- before exercising the /add, /get, /edit, /delete routes, e.g.:
+--   mysql -h "$DATABASE_HOST" -P "$DATABASE_PORT" -u "$DATABASE_USER" -p "$DATABASE_NAME" < data/schema.sql
+
+CREATE TABLE IF NOT EXISTS items (
+    id    INT AUTO_INCREMENT PRIMARY KEY,
+    name  VARCHAR(255) NOT NULL,
+    value VARCHAR(255) NOT NULL
+);

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -42,57 +42,43 @@ const docTemplate = `{
         },
         "/add": {
             "post": {
-                "description": "Stub handler that is meant to add something to the database; currently builds a placeholder struct, JSON-encodes it via data.JsonConvert, and writes it back. The route is registered without a method restriction, so it currently responds to any HTTP method.",
+                "description": "Creates a new row in the items table (see data/schema.sql) from a JSON body and returns the created item, including its generated id. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "rest"
                 ],
-                "summary": "Add a resource",
-                "responses": {
-                    "200": {
-                        "description": "placeholder JSON payload",
+                "summary": "Add an item",
+                "parameters": [
+                    {
+                        "description": "Item to create",
+                        "name": "item",
+                        "in": "body",
+                        "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/handlers.AddRequest"
                         }
                     }
-                }
-            }
-        },
-        "/auth/login": {
-            "get": {
-                "description": "Stub handler that is meant to fetch something from the database based on the request; currently just writes a fixed string. Also currently reused (as-is) for /auth/login, /auth/user/new and /auth/user/remove.",
-                "produces": [
-                    "text/plain"
                 ],
-                "tags": [
-                    "rest"
-                ],
-                "summary": "Get a resource",
                 "responses": {
-                    "200": {
-                        "description": "Getting something from database",
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/data.Item"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid request body",
                         "schema": {
                             "type": "string"
                         }
-                    }
-                }
-            }
-        },
-        "/auth/user/new": {
-            "get": {
-                "description": "Stub handler that is meant to fetch something from the database based on the request; currently just writes a fixed string. Also currently reused (as-is) for /auth/login, /auth/user/new and /auth/user/remove.",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "rest"
-                ],
-                "summary": "Get a resource",
-                "responses": {
-                    "200": {
-                        "description": "Getting something from database",
+                    },
+                    "500": {
+                        "description": "database error",
                         "schema": {
                             "type": "string"
                         }
@@ -102,17 +88,44 @@ const docTemplate = `{
         },
         "/delete": {
             "delete": {
-                "description": "Stub handler that is meant to delete something from the database; currently just writes a fixed string. The route is registered without a method restriction, so it currently responds to any HTTP method.",
+                "description": "Deletes the row in the items table (see data/schema.sql) identified by the ` + "`" + `id` + "`" + ` query parameter and confirms deletion as JSON. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.",
                 "produces": [
-                    "text/plain"
+                    "application/json"
                 ],
                 "tags": [
                     "rest"
                 ],
-                "summary": "Delete a resource",
+                "summary": "Delete an item",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Item id",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Something is going to be deleted",
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.DeleteResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "missing or invalid id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "item not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "database error",
                         "schema": {
                             "type": "string"
                         }
@@ -142,17 +155,56 @@ const docTemplate = `{
         },
         "/edit": {
             "put": {
-                "description": "Stub handler that is meant to edit something in the database; currently just writes a fixed string. The route is registered without a method restriction, so it currently responds to any HTTP method.",
+                "description": "Updates the name/value of the row in the items table (see data/schema.sql) identified by the ` + "`" + `id` + "`" + ` query parameter, from a JSON body, and returns the updated item. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
-                    "text/plain"
+                    "application/json"
                 ],
                 "tags": [
                     "rest"
                 ],
-                "summary": "Edit a resource",
+                "summary": "Edit an item",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Item id",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "item",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.EditRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Something is going to be edited",
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/data.Item"
+                        }
+                    },
+                    "400": {
+                        "description": "missing/invalid id or request body",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "item not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "database error",
                         "schema": {
                             "type": "string"
                         }
@@ -162,17 +214,44 @@ const docTemplate = `{
         },
         "/get": {
             "get": {
-                "description": "Stub handler that is meant to fetch something from the database based on the request; currently just writes a fixed string. Also currently reused (as-is) for /auth/login, /auth/user/new and /auth/user/remove.",
+                "description": "Fetches a single row from the items table (see data/schema.sql) by its id, passed as the ` + "`" + `id` + "`" + ` query parameter, and returns it as JSON. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.",
                 "produces": [
-                    "text/plain"
+                    "application/json"
                 ],
                 "tags": [
                     "rest"
                 ],
-                "summary": "Get a resource",
+                "summary": "Get an item",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Item id",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Getting something from database",
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/data.Item"
+                        }
+                    },
+                    "400": {
+                        "description": "missing or invalid id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "item not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "database error",
                         "schema": {
                             "type": "string"
                         }
@@ -217,6 +296,55 @@ const docTemplate = `{
                             "type": "string"
                         }
                     }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "data.Item": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.AddRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.DeleteResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.EditRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -36,57 +36,43 @@
         },
         "/add": {
             "post": {
-                "description": "Stub handler that is meant to add something to the database; currently builds a placeholder struct, JSON-encodes it via data.JsonConvert, and writes it back. The route is registered without a method restriction, so it currently responds to any HTTP method.",
+                "description": "Creates a new row in the items table (see data/schema.sql) from a JSON body and returns the created item, including its generated id. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "rest"
                 ],
-                "summary": "Add a resource",
-                "responses": {
-                    "200": {
-                        "description": "placeholder JSON payload",
+                "summary": "Add an item",
+                "parameters": [
+                    {
+                        "description": "Item to create",
+                        "name": "item",
+                        "in": "body",
+                        "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/handlers.AddRequest"
                         }
                     }
-                }
-            }
-        },
-        "/auth/login": {
-            "get": {
-                "description": "Stub handler that is meant to fetch something from the database based on the request; currently just writes a fixed string. Also currently reused (as-is) for /auth/login, /auth/user/new and /auth/user/remove.",
-                "produces": [
-                    "text/plain"
                 ],
-                "tags": [
-                    "rest"
-                ],
-                "summary": "Get a resource",
                 "responses": {
-                    "200": {
-                        "description": "Getting something from database",
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/data.Item"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid request body",
                         "schema": {
                             "type": "string"
                         }
-                    }
-                }
-            }
-        },
-        "/auth/user/new": {
-            "get": {
-                "description": "Stub handler that is meant to fetch something from the database based on the request; currently just writes a fixed string. Also currently reused (as-is) for /auth/login, /auth/user/new and /auth/user/remove.",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "rest"
-                ],
-                "summary": "Get a resource",
-                "responses": {
-                    "200": {
-                        "description": "Getting something from database",
+                    },
+                    "500": {
+                        "description": "database error",
                         "schema": {
                             "type": "string"
                         }
@@ -96,17 +82,44 @@
         },
         "/delete": {
             "delete": {
-                "description": "Stub handler that is meant to delete something from the database; currently just writes a fixed string. The route is registered without a method restriction, so it currently responds to any HTTP method.",
+                "description": "Deletes the row in the items table (see data/schema.sql) identified by the `id` query parameter and confirms deletion as JSON. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.",
                 "produces": [
-                    "text/plain"
+                    "application/json"
                 ],
                 "tags": [
                     "rest"
                 ],
-                "summary": "Delete a resource",
+                "summary": "Delete an item",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Item id",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Something is going to be deleted",
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.DeleteResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "missing or invalid id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "item not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "database error",
                         "schema": {
                             "type": "string"
                         }
@@ -136,17 +149,56 @@
         },
         "/edit": {
             "put": {
-                "description": "Stub handler that is meant to edit something in the database; currently just writes a fixed string. The route is registered without a method restriction, so it currently responds to any HTTP method.",
+                "description": "Updates the name/value of the row in the items table (see data/schema.sql) identified by the `id` query parameter, from a JSON body, and returns the updated item. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
-                    "text/plain"
+                    "application/json"
                 ],
                 "tags": [
                     "rest"
                 ],
-                "summary": "Edit a resource",
+                "summary": "Edit an item",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Item id",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "item",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.EditRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Something is going to be edited",
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/data.Item"
+                        }
+                    },
+                    "400": {
+                        "description": "missing/invalid id or request body",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "item not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "database error",
                         "schema": {
                             "type": "string"
                         }
@@ -156,17 +208,44 @@
         },
         "/get": {
             "get": {
-                "description": "Stub handler that is meant to fetch something from the database based on the request; currently just writes a fixed string. Also currently reused (as-is) for /auth/login, /auth/user/new and /auth/user/remove.",
+                "description": "Fetches a single row from the items table (see data/schema.sql) by its id, passed as the `id` query parameter, and returns it as JSON. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.",
                 "produces": [
-                    "text/plain"
+                    "application/json"
                 ],
                 "tags": [
                     "rest"
                 ],
-                "summary": "Get a resource",
+                "summary": "Get an item",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Item id",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Getting something from database",
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/data.Item"
+                        }
+                    },
+                    "400": {
+                        "description": "missing or invalid id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "item not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "database error",
                         "schema": {
                             "type": "string"
                         }
@@ -211,6 +290,55 @@
                             "type": "string"
                         }
                     }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "data.Item": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.AddRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.DeleteResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.EditRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
                 }
             }
         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,35 @@
 basePath: /
+definitions:
+  data.Item:
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      value:
+        type: string
+    type: object
+  handlers.AddRequest:
+    properties:
+      name:
+        type: string
+      value:
+        type: string
+    type: object
+  handlers.DeleteResponse:
+    properties:
+      deleted:
+        type: boolean
+      id:
+        type: integer
+    type: object
+  handlers.EditRequest:
+    properties:
+      name:
+        type: string
+      value:
+        type: string
+    type: object
 host: localhost:6969
 info:
   contact:
@@ -28,63 +59,69 @@ paths:
       - general
   /add:
     post:
-      description: Stub handler that is meant to add something to the database; currently
-        builds a placeholder struct, JSON-encodes it via data.JsonConvert, and writes
-        it back. The route is registered without a method restriction, so it currently
-        responds to any HTTP method.
+      consumes:
+      - application/json
+      description: Creates a new row in the items table (see data/schema.sql) from
+        a JSON body and returns the created item, including its generated id. Real
+        MySQL-backed CRUD via the data package, demonstrating database wiring rather
+        than a stub response.
+      parameters:
+      - description: Item to create
+        in: body
+        name: item
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.AddRequest'
       produces:
       - application/json
       responses:
-        "200":
-          description: placeholder JSON payload
+        "201":
+          description: Created
           schema:
-            type: object
-      summary: Add a resource
-      tags:
-      - rest
-  /auth/login:
-    get:
-      description: Stub handler that is meant to fetch something from the database
-        based on the request; currently just writes a fixed string. Also currently
-        reused (as-is) for /auth/login, /auth/user/new and /auth/user/remove.
-      produces:
-      - text/plain
-      responses:
-        "200":
-          description: Getting something from database
+            $ref: '#/definitions/data.Item'
+        "400":
+          description: invalid request body
           schema:
             type: string
-      summary: Get a resource
-      tags:
-      - rest
-  /auth/user/new:
-    get:
-      description: Stub handler that is meant to fetch something from the database
-        based on the request; currently just writes a fixed string. Also currently
-        reused (as-is) for /auth/login, /auth/user/new and /auth/user/remove.
-      produces:
-      - text/plain
-      responses:
-        "200":
-          description: Getting something from database
+        "500":
+          description: database error
           schema:
             type: string
-      summary: Get a resource
+      summary: Add an item
       tags:
       - rest
   /delete:
     delete:
-      description: Stub handler that is meant to delete something from the database;
-        currently just writes a fixed string. The route is registered without a method
-        restriction, so it currently responds to any HTTP method.
+      description: Deletes the row in the items table (see data/schema.sql) identified
+        by the `id` query parameter and confirms deletion as JSON. Real MySQL-backed
+        CRUD via the data package, demonstrating database wiring rather than a stub
+        response.
+      parameters:
+      - description: Item id
+        in: query
+        name: id
+        required: true
+        type: integer
       produces:
-      - text/plain
+      - application/json
       responses:
         "200":
-          description: Something is going to be deleted
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.DeleteResponse'
+        "400":
+          description: missing or invalid id
           schema:
             type: string
-      summary: Delete a resource
+        "404":
+          description: item not found
+          schema:
+            type: string
+        "500":
+          description: database error
+          schema:
+            type: string
+      summary: Delete an item
       tags:
       - rest
   /docs:
@@ -103,32 +140,78 @@ paths:
       - general
   /edit:
     put:
-      description: Stub handler that is meant to edit something in the database; currently
-        just writes a fixed string. The route is registered without a method restriction,
-        so it currently responds to any HTTP method.
+      consumes:
+      - application/json
+      description: Updates the name/value of the row in the items table (see data/schema.sql)
+        identified by the `id` query parameter, from a JSON body, and returns the
+        updated item. Real MySQL-backed CRUD via the data package, demonstrating database
+        wiring rather than a stub response.
+      parameters:
+      - description: Item id
+        in: query
+        name: id
+        required: true
+        type: integer
+      - description: Fields to update
+        in: body
+        name: item
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.EditRequest'
       produces:
-      - text/plain
+      - application/json
       responses:
         "200":
-          description: Something is going to be edited
+          description: OK
+          schema:
+            $ref: '#/definitions/data.Item'
+        "400":
+          description: missing/invalid id or request body
           schema:
             type: string
-      summary: Edit a resource
+        "404":
+          description: item not found
+          schema:
+            type: string
+        "500":
+          description: database error
+          schema:
+            type: string
+      summary: Edit an item
       tags:
       - rest
   /get:
     get:
-      description: Stub handler that is meant to fetch something from the database
-        based on the request; currently just writes a fixed string. Also currently
-        reused (as-is) for /auth/login, /auth/user/new and /auth/user/remove.
+      description: Fetches a single row from the items table (see data/schema.sql)
+        by its id, passed as the `id` query parameter, and returns it as JSON. Real
+        MySQL-backed CRUD via the data package, demonstrating database wiring rather
+        than a stub response.
+      parameters:
+      - description: Item id
+        in: query
+        name: id
+        required: true
+        type: integer
       produces:
-      - text/plain
+      - application/json
       responses:
         "200":
-          description: Getting something from database
+          description: OK
+          schema:
+            $ref: '#/definitions/data.Item'
+        "400":
+          description: missing or invalid id
           schema:
             type: string
-      summary: Get a resource
+        "404":
+          description: item not found
+          schema:
+            type: string
+        "500":
+          description: database error
+          schema:
+            type: string
+      summary: Get an item
       tags:
       - rest
   /home:

--- a/handlers/add.go
+++ b/handlers/add.go
@@ -1,28 +1,59 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/byte-cats/microman/data"
 )
 
-type Dammit struct {
-	well string
-	ok   int
+// AddRequest is the expected JSON body for POST /add.
+type AddRequest struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // Adder godoc
-// @Summary Add a resource
-// @Description Stub handler that is meant to add something to the database; currently builds a placeholder struct, JSON-encodes it via data.JsonConvert, and writes it back. The route is registered without a method restriction, so it currently responds to any HTTP method.
+// @Summary Add an item
+// @Description Creates a new row in the items table (see data/schema.sql) from a JSON body and returns the created item, including its generated id. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.
 // @Tags rest
+// @Accept json
 // @Produce json
-// @Success 200 {object} object "placeholder JSON payload"
+// @Param item body handlers.AddRequest true "Item to create"
+// @Success 201 {object} data.Item
+// @Failure 400 {string} string "invalid request body"
+// @Failure 500 {string} string "database error"
 // @Router /add [post]
 func Adder(w http.ResponseWriter, r *http.Request) {
-	d := Dammit{
-		well: "yes",
-		ok:   1,
+	var req AddRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
 	}
-	cont, _ := data.JsonConvert(d)
+	if req.Name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	db, err := data.Connect()
+	if err != nil {
+		http.Error(w, "database connection failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer data.Close(db)
+
+	item, err := data.CreateItem(db, req.Name, req.Value)
+	if err != nil {
+		http.Error(w, "failed to create item: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	cont, err := data.JsonConvert(item)
+	if err != nil {
+		http.Error(w, "failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
 	writeString(w, cont)
 }

--- a/handlers/delete.go
+++ b/handlers/delete.go
@@ -2,15 +2,56 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
+
+	"github.com/byte-cats/microman/data"
 )
 
+// DeleteResponse is the JSON body returned by DELETE /delete on success.
+type DeleteResponse struct {
+	Deleted bool `json:"deleted"`
+	ID      int  `json:"id"`
+}
+
 // Deleter godoc
-// @Summary Delete a resource
-// @Description Stub handler that is meant to delete something from the database; currently just writes a fixed string. The route is registered without a method restriction, so it currently responds to any HTTP method.
+// @Summary Delete an item
+// @Description Deletes the row in the items table (see data/schema.sql) identified by the `id` query parameter and confirms deletion as JSON. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.
 // @Tags rest
-// @Produce plain
-// @Success 200 {string} string "Something is going to be deleted"
+// @Produce json
+// @Param id query int true "Item id"
+// @Success 200 {object} handlers.DeleteResponse
+// @Failure 400 {string} string "missing or invalid id"
+// @Failure 404 {string} string "item not found"
+// @Failure 500 {string} string "database error"
 // @Router /delete [delete]
 func Deleter(w http.ResponseWriter, r *http.Request) {
-	writeString(w, "Something is going to be deleted")
+	id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	if err != nil {
+		http.Error(w, "missing or invalid id query parameter", http.StatusBadRequest)
+		return
+	}
+
+	db, err := data.Connect()
+	if err != nil {
+		http.Error(w, "database connection failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer data.Close(db)
+
+	if err := data.DeleteItem(db, id); err != nil {
+		if err == data.ErrItemNotFound {
+			http.Error(w, "item not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to delete item: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	cont, err := data.JsonConvert(DeleteResponse{Deleted: true, ID: id})
+	if err != nil {
+		http.Error(w, "failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeString(w, cont)
 }

--- a/handlers/edit.go
+++ b/handlers/edit.go
@@ -1,16 +1,71 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
+	"strconv"
+
+	"github.com/byte-cats/microman/data"
 )
 
+// EditRequest is the expected JSON body for PUT /edit.
+type EditRequest struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // Editor godoc
-// @Summary Edit a resource
-// @Description Stub handler that is meant to edit something in the database; currently just writes a fixed string. The route is registered without a method restriction, so it currently responds to any HTTP method.
+// @Summary Edit an item
+// @Description Updates the name/value of the row in the items table (see data/schema.sql) identified by the `id` query parameter, from a JSON body, and returns the updated item. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.
 // @Tags rest
-// @Produce plain
-// @Success 200 {string} string "Something is going to be edited"
+// @Accept json
+// @Produce json
+// @Param id query int true "Item id"
+// @Param item body handlers.EditRequest true "Fields to update"
+// @Success 200 {object} data.Item
+// @Failure 400 {string} string "missing/invalid id or request body"
+// @Failure 404 {string} string "item not found"
+// @Failure 500 {string} string "database error"
 // @Router /edit [put]
 func Editor(w http.ResponseWriter, r *http.Request) {
-	writeString(w, "Something is going to be edited")
+	id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	if err != nil {
+		http.Error(w, "missing or invalid id query parameter", http.StatusBadRequest)
+		return
+	}
+
+	var req EditRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	db, err := data.Connect()
+	if err != nil {
+		http.Error(w, "database connection failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer data.Close(db)
+
+	item, err := data.UpdateItem(db, id, req.Name, req.Value)
+	if err != nil {
+		if err == data.ErrItemNotFound {
+			http.Error(w, "item not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to update item: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	cont, err := data.JsonConvert(item)
+	if err != nil {
+		http.Error(w, "failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeString(w, cont)
 }

--- a/handlers/get.go
+++ b/handlers/get.go
@@ -2,15 +2,51 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
+
+	"github.com/byte-cats/microman/data"
 )
 
 // Get godoc
-// @Summary Get a resource
-// @Description Stub handler that is meant to fetch something from the database based on the request; currently just writes a fixed string.
+// @Summary Get an item
+// @Description Fetches a single row from the items table (see data/schema.sql) by its id, passed as the `id` query parameter, and returns it as JSON. Real MySQL-backed CRUD via the data package, demonstrating database wiring rather than a stub response.
 // @Tags rest
-// @Produce plain
-// @Success 200 {string} string "Getting something from database"
+// @Produce json
+// @Param id query int true "Item id"
+// @Success 200 {object} data.Item
+// @Failure 400 {string} string "missing or invalid id"
+// @Failure 404 {string} string "item not found"
+// @Failure 500 {string} string "database error"
 // @Router /get [get]
 func Get(w http.ResponseWriter, r *http.Request) {
-	writeString(w, "Getting something from database")
+	id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	if err != nil {
+		http.Error(w, "missing or invalid id query parameter", http.StatusBadRequest)
+		return
+	}
+
+	db, err := data.Connect()
+	if err != nil {
+		http.Error(w, "database connection failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer data.Close(db)
+
+	item, err := data.GetItem(db, id)
+	if err != nil {
+		if err == data.ErrItemNotFound {
+			http.Error(w, "item not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to get item: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	cont, err := data.JsonConvert(item)
+	if err != nil {
+		http.Error(w, "failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeString(w, cont)
 }

--- a/server/routing.go
+++ b/server/routing.go
@@ -26,8 +26,8 @@ func InitRoutes(router *mux.Router) {
 	auth.AuthRoute(router)
 
 	// Rest endpoints
-	router.HandleFunc("/get", handlers.Get)
-	router.HandleFunc("/add", handlers.Adder)
-	router.HandleFunc("/edit", handlers.Editor)
-	router.HandleFunc("/delete", handlers.Deleter)
+	router.HandleFunc("/get", handlers.Get).Methods("GET")
+	router.HandleFunc("/add", handlers.Adder).Methods("POST")
+	router.HandleFunc("/edit", handlers.Editor).Methods("PUT")
+	router.HandleFunc("/delete", handlers.Deleter).Methods("DELETE")
 }


### PR DESCRIPTION
## Summary

Checks off the `- [ ] Example Database Use` box in the README by replacing the fake CRUD stubs in `handlers/add.go`/`get.go`/`edit.go`/`delete.go` with genuine database-backed handlers for a minimal example resource, `Item`, using `database/sql` directly through the `data` package (`data.Connect()`/`data.Close()`, already wired to MySQL via `byte-cats/datastation`).

### Schema (`data/schema.sql`)

```sql
CREATE TABLE IF NOT EXISTS items (
    id    INT AUTO_INCREMENT PRIMARY KEY,
    name  VARCHAR(255) NOT NULL,
    value VARCHAR(255) NOT NULL
);
```

`data/items.go` adds `Item{ID, Name, Value}` plus `CreateItem`/`GetItem`/`UpdateItem`/`DeleteItem` — all parameterized `database/sql` queries against `*sql.DB` (no string concatenation).

### Endpoint request/response shapes

| Route | Method | Request | Response |
|---|---|---|---|
| `/add` | `POST` | JSON body `{"name": "...", "value": "..."}` | `201` + JSON `data.Item` (with generated `id`) |
| `/get` | `GET` | `?id=<int>` query param | `200` + JSON `data.Item`, `404` if not found |
| `/edit` | `PUT` | `?id=<int>` + JSON body `{"name": "...", "value": "..."}` | `200` + JSON updated `data.Item`, `404` if not found |
| `/delete` | `DELETE` | `?id=<int>` query param | `200` + JSON `{"deleted": true, "id": <int>}`, `404` if not found |

All four handlers now: open a connection via `data.Connect()` (returning a clean `500` with the real error on failure, never panicking or faking success), call the matching `data.*Item` function, `defer data.Close(db)`, and write a real JSON response via `data.JsonConvert`.

`server/routing.go` now restricts these four routes to their real HTTP methods (`GET`/`POST`/`PUT`/`DELETE`) instead of accepting any method.

Swagger docs (`docs/docs.go`, `docs/swagger.json`, `docs/swagger.yaml`) were regenerated via `swag init -g cmd/microguy/main.go` from the updated handler doc comments. This also fixed some pre-existing staleness in the generated docs (e.g. `/get`'s old description falsely claiming it was reused for `/auth/login` and `/auth/user/new`, which isn't the case in the current source).

### Not touched

`auth/`, `.github/workflows/`, `Dockerfile`, `deploy/`, `Makefile` — per instructions, these are other workstreams' territory. `go.mod`/`go.sum` were untouched since `github.com/go-sql-driver/mysql` was already an indirect dependency via `datastation`.

### Testing

No live MySQL instance is available in this environment, so the CRUD functions in `data/items.go` are correct-by-inspection parameterized SQL against the schema above rather than unit-tested against a live DB (per the task's guidance, not faking a mock DB layer for coverage).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (existing suite still passes)
- [ ] Manual verification against a live MySQL instance (apply `data/schema.sql`, then exercise `POST /add`, `GET /get?id=`, `PUT /edit?id=`, `DELETE /delete?id=`) — not possible in this sandboxed environment, left for reviewer/CI with real `DATABASE_*` env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXmPNJBsdksoQ3obkj6RJ5